### PR TITLE
Allow printing of blobs in regular data.frames

### DIFF
--- a/R/format.R
+++ b/R/format.R
@@ -31,7 +31,7 @@ obj_sum.blob <- function(x) {
 #' @importFrom tibble is_vector_s3
 is_vector_s3.blob <- function(x) TRUE
 
-blob_size <- function(x, digits = 3, trim = TRUE) {
+blob_size <- function(x, digits = 3, trim = TRUE, ...) {
   x <- vapply(x, length, integer(1))
 
   power <- min(floor(log(abs(x), 1000)), 4)
@@ -42,7 +42,7 @@ blob_size <- function(x, digits = 3, trim = TRUE) {
     x <- x / (1024 ^ power)
   }
 
-  x1 <- signif(x, digits = digits)
+  x1 <- signif(x, digits = digits %||% 3)
   x2 <- format(x1, big.mark = ",", scientific = FALSE, trim = trim)
   paste0(x2, " ", unit)
 }

--- a/R/util.R
+++ b/R/util.R
@@ -11,3 +11,4 @@ is_raw_list <- function(x) {
   TRUE
 }
 
+`%||%` <- function(x, y) if (is.null(x)) y else x


### PR DESCRIPTION
- `blob_size()` needs to ignore extra arguments
- digits is set to `NULL` by `print.data.frame()`, so this case needs to use the default (3).

A reprex for this (which works after this PR)

``` r
iris$blob <- as.blob(lapply(seq_len(nrow(iris)), function(x) as.raw(sample(0:100, size = 
sample(0:25, 1)))))
print(head(iris))
#>   Sepal.Length Sepal.Width Petal.Length Petal.Width Species       blob
#> 1          5.1         3.5          1.4         0.2  setosa blob[12 B]
#> 2          4.9         3.0          1.4         0.2  setosa blob[19 B]
#> 3          4.7         3.2          1.3         0.2  setosa  blob[7 B]
#> 4          4.6         3.1          1.5         0.2  setosa blob[10 B]
#> 5          5.0         3.6          1.4         0.2  setosa blob[18 B]
#> 6          5.4         3.9          1.7         0.4  setosa  blob[4 B]
```
